### PR TITLE
resolves bare variables deprecation warning

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -12,9 +12,9 @@
 - name: Configure additional repos in /etc/yum.repos.d/
   template:
     src: yum_repo.j2
-    dest: /etc/yum.repos.d/{{ item.key }}.repo
+    dest: "/etc/yum.repos.d/{{ item.key }}.repo"
   register: repo_file
-  with_dict: yumrepo_repos
+  with_dict: "{{ yumrepo_repos }}"
   when: yumrepo_repos.keys() | length > 0
   notify:
     - Delete unmanaged repos
@@ -26,7 +26,7 @@
       replace('$releasever', ansible_distribution_major_version) |
       replace('$arch', ansible_architecture) |
       replace('$basearch', ansible_architecture) }}"
-  with_dict: yumrepo_repos
+  with_dict: "{{ yumrepo_repos }}"
   when: >
     item.value.gpgkey is defined and
     item.value.gpgcheck == 1
@@ -41,10 +41,10 @@
 - name: Create fragments for repos to be ignored
   lineinfile:
     line: "{{ item }}"
-    dest: /tmp/ansible.yumrepo.{{ yumrepo_unique }}/{{ item }}
+    dest: "/tmp/ansible.yumrepo.{{ yumrepo_unique }}/{{ item }}"
     create: yes
     state: present
-  with_items: yumrepo_ignore_repos
+  with_items: "{{ yumrepo_ignore_repos }}"
   changed_when: False
   when: >
     yumrepo_manage and
@@ -53,10 +53,10 @@
 - name: Create fragment files
   lineinfile:
     line: "{{ item.key }}.repo"
-    dest: /tmp/ansible.yumrepo.{{ yumrepo_unique }}/{{ item.key }}
+    dest: "/tmp/ansible.yumrepo.{{ yumrepo_unique }}/{{ item.key }}"
     create: yes
     state: present
-  with_dict: yumrepo_repos
+  with_dict: "{{ yumrepo_repos }}"
   changed_when: False
   when: >
     yumrepo_manage and


### PR DESCRIPTION
This fixes the deprecation warnings in Ansible 2 such as the following:

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your 
playbooks so that the environment value uses the full variable syntax 
('{{yumrepo_repos}}'). This feature will be removed in a future release. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
```
